### PR TITLE
Change word comparison to relation

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
     </div>
 
     <div class="infobox">
-      <div class="infobox-inner">If we drill into individual age groups, it is almost impossible to find a meaningful comparison to American incarceration in public data.</div>
+      <div class="infobox-inner">If we drill into individual age groups, it is almost impossible to find a meaningful relation to American incarceration in public data.</div>
     </div>
 
     <div id="estimated" class="infobox chart repression infobox-near" style="margin-bottom: 3900px;">


### PR DESCRIPTION
Hi! @MKorostoff 
I didn't understand this paragraph accurately.

> If we drill into individual age groups, it is almost impossible to find a meaningful comparison to American incarceration in public data.

Did you mean `relation` instead of `comparison`?